### PR TITLE
kubernetes-networks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: bash
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ slobanov Platform repository
     * `03-jane-to-admin-binding.yaml` - привязка роли `admin` к `jane` в рамках `Namespace`'а `dev`.
     * `04-ken-account.yaml` -  создание `ServiceAccount` `ken` в `Namespace`'е `dev`.
     * `05-ken-to-view-binding.yaml` - привязка роли `view` к `ken` в рамках `Namespace`'а `dev`.
+* kubernetes-networks
+  * `coredns-svc-tcp-lb.yaml` - `LoadBalancer` `Service`, exposing `kute-system`'s `core-dns` `Pods` on TCP:53 for usage outside of the cluster.
+  * `coredns-svc-udp-lb.yaml` - `LoadBalancer` `Service`, exposing `kute-system`'s `core-dns` `Pods` on UDP:53 for usage outside of the cluster.
+  * `dashboard-ingress.yaml` - `Ingress` for routing trafic to kubernetes-dashboard `Service`.
+  * `metallb-config.yaml` - `ConfigMap`, used for `Metallb` configuration.
+  * `nginx-lb.yaml` - `LoadBalancer` `Service`, exposing NGINX Ingress controller.
+  * `web-deploy.yaml` - `Deployment` for `web` application, described in kubernetes-into section.
+  * `web-ingress.yaml` - `Ingress` for accessing `web-svc` `Service`.
+  * `web-svc-cip.yaml` - `ClusterIP` `Service` for `web` application `Pods`.
+  * `web-svc-headless-yaml` - headless `Service` for `web` application `Pods`.
+  * `web-svc-lb.yaml` - `LoadBalancer` `Service` for `web` application `Pods`.
+  * `canary/` - `Deployment`, `Service` and `Ingress` for canary deployment pattern.
 
 -----
 Sergey Lobanov

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -14,6 +14,13 @@ spec:
     volumeMounts:
     - mountPath: /app
       name: app
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 8000
+    livenessProbe:
+      tcpSocket:
+        port: 8000
   initContainers:
   - name: init-web
     image: "busybox:1.31.0"

--- a/kubernetes-networks/canary/web-ingress-canary.yaml
+++ b/kubernetes-networks/canary/web-ingress-canary.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web-new
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "web-new"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend: 
+          serviceName: web-new-svc
+          servicePort: 8000

--- a/kubernetes-networks/canary/web-new-deploy.yaml
+++ b/kubernetes-networks/canary/web-new-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-new
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-new
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web-new
+      labels:
+        app: web-new
+    spec:
+      volumes:
+      - name: app
+        emptyDir: {}
+      containers:
+      - name: web
+        image: "slobanov/kubernetes-intro:1.0.0"
+        volumeMounts:
+        - mountPath: /app
+          name: app
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+      initContainers:
+      - name: init-web
+        image: "busybox:1.31.0"
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - mountPath: /app
+          name: app

--- a/kubernetes-networks/canary/web-new-svc-headless.yaml
+++ b/kubernetes-networks/canary/web-new-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-new-svc
+spec:
+  selector:
+    app: web-new
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/coredns-svc-tcp-lb.yaml
+++ b/kubernetes-networks/coredns-svc-tcp-lb.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-tcp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-key
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.5
+  ports:
+  - protocol: TCP
+    port: 53
+    targetPort: 53

--- a/kubernetes-networks/coredns-svc-udp-lb.yaml
+++ b/kubernetes-networks/coredns-svc-udp-lb.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-udp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-key
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.5
+  ports:
+  - protocol: UDP
+    port: 53
+    targetPort: 53

--- a/kubernetes-networks/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations: 
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        backend: 
+          serviceName: kubernetes-dashboard
+          servicePort: 8443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -9,4 +9,4 @@ data:
     - name: default
       protocol: layer2
       addresses:
-        - "172.17.255.1-172.17.255.254"
+        - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+        - "172.17.255.1-172.17.255.254"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector: 
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+  - { name: http, port: 80, targetPort: http }
+  - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      volumes:
+      - name: app
+        emptyDir: {}
+      containers:
+      - name: web
+        image: "slobanov/kubernetes-intro:1.0.0"
+        volumeMounts:
+        - mountPath: /app
+          name: app
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+      initContainers:
+      - name: init-web
+        image: "busybox:1.31.0"
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - mountPath: /app
+          name: app

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations: 
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend: 
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со * (кроме canary)

## В процессе сделано:
 - Для пода `web` добавлены `livenessProbe` and `readinessProbe` проверки.
 - Для приложения `web` был создан `Deplyment` с тремя репликами и стретегий применения `RollingUpdate`.
 - Для подов `web` были созданы сервисы (`Service`) вида `ClusterIp`, `LoadBalancer` и `headless`.
 - Установлен и настроен `MetalLb` с помощью `ConfigMap`.
 - Созданы два `Service` для доступа к `CoreDNS` снаружи кластера.
 - Установлен `ingress-nginx` контроллер и создан `LoadBalancer` сервис для него,
 - Создан `Ingress` для сервиса `web-svc` (это `headless` сервис для подов `web`) по пути /web.
 - Создаг `Ingress` для доступа к сервису `kubernetes-dashboard` по пути /dashboard.
 - C канареечным развертыванием не вышло... Не смог понять, зачем мне host в правилах Ingress и можно ли сделать без него. (то, что сделал я лежит в папке /canary и не работает - подробности были в slack)

## Как проверить работоспособность:
 - nslookup web-svc.default.svc.cluster.local 172.17.255.5 должен найти адреса сервиса `web-svc` - этим проверим доступность `CoreDNS`снаружи кластера.
 - Пусть 172.17.255.2 - адрес `LoadBalancer` сервиса для `nginx-ingress`:
   - Запрос 172.17.255.2/web/ успешно вернет страницу сервиса `web`.
   - Запрос 172.17.255.2/dashboard/ вернет страницу `kubernetes-dashboard` .

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
