### PR TITLE
add kubernetes-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ slobanov Platform repository
   * minio-sercret.yaml - `Sercret`, storing accessKey and secretKey for minio application in base64.
   * minio-statefulset.yaml - `StatefulSet` for running minio.
   * minio-headless-service.yaml - headless `Service` for minio `Pods`.
+* kubernetes-storage
+  * cluster/cluster.yaml - cluster config for kind for VolumeSnapshotDataSource support.
+  * hw/01-storage-class.yaml - `StorageClass`, describing CSI hostpath provisioner.
+  * hw/02-storage-pvc.yaml - `PersistentVolumeClaim` for binding with hostpath `PVs`, provided by `csi-hostpath-sc`.
+  * hw/03-storage-pod.yaml - `Pod` with volume, mouted to `/data`, claimed from storage-pvc.
 
 -----
 Sergey Lobanov

--- a/kubernetes-storage/cluster/cluster.yaml
+++ b/kubernetes-storage/cluster/cluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kind: Cluster
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "feature-gates": "VolumeSnapshotDataSource=true"
+  scheduler:
+    extraArgs:
+      "feature-gates": "VolumeSnapshotDataSource=true"
+  controllerManager:
+    extraArgs:
+      "feature-gates": "VolumeSnapshotDataSource=true"
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: InitConfiguration
+  metadata:
+    name: config

--- a/kubernetes-storage/hw/01-storage-class.yaml
+++ b/kubernetes-storage/hw/01-storage-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/kubernetes-storage/hw/02-storage-pvc.yaml
+++ b/kubernetes-storage/hw/02-storage-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 700Mi

--- a/kubernetes-storage/hw/03-storage-pod.yaml
+++ b/kubernetes-storage/hw/03-storage-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+spec:
+  containers:
+  - name: storage-container
+    image: ubuntu:18.04
+    command: ["/bin/bash", "-ec", "while true; do sleep 10; done;"]
+    volumeMounts:
+    - mountPath: /data
+      name: storage-volume
+  volumes:
+  - name: storage-volume
+    persistentVolumeClaim:
+      claimName: storage-pvc


### PR DESCRIPTION
# Выполнено ДЗ №5

 - [X] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - cluster/cluster.yaml - конфиг для kind для поддержки VolumeSnapshotDataSource.
 - hw/01-storage-class.yaml - StorageClass для CSI Host Path Driver.
 - hw/02-storage-pvc.yaml - объект PVC c именем storage-pvc.
 - hw/03-storage-pod.yaml - объект Pod c именем storage-pod с volume, смонтированным в /data.

## Как запустить проект:
 - В `cluster`: `kind cluster create --config --config cluster.yaml`.
 - Установить csi-driver-host-path (https://github.com/kubernetes-csi/csi-driver-host-path).
 - В `hw`: 
    * `kubectl apply -f 01-storage-pod.yaml`.
    * `kubectl apply -f 02-storage-pod.yaml`.
    * `kubectl apply -f 03-storage-pod.yaml`.
  
## Как проверить работоспособность:
```bash
$ kubectl get storageclasses.storage.k8s.io csi-hostpath-sc
NAME              PROVISIONER           AGE
csi-hostpath-sc   hostpath.csi.k8s.io   51m
```
```bash
$ kubectl get pvc storage-pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
storage-pvc   Bound    pvc-21a99a70-bd6b-439b-8651-3a2cd7333f78   700Mi      RWO            csi-hostpath-sc   27m
```
```bash
$ kubectl get pod storage-pod
NAME          READY   STATUS    RESTARTS   AGE
storage-pod   1/1     Running   0          25m
```

## PR checklist:
 - [X] Выставлен label с номером домашнего задания
